### PR TITLE
Fix Netlify build failure due to OpenSSL incompatibility with Node 22

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "yarn run build"
+  publish = "public"
+
+[build.environment]
+  NODE_OPTIONS = "--openssl-legacy-provider"


### PR DESCRIPTION
Adds netlify.toml with NODE_OPTIONS=--openssl-legacy-provider to fix ERR_OSSL_EVP_UNSUPPORTED error caused by Node 22's OpenSSL 3 dropping support for the MD4 hash algorithm used by Gatsby 3's webpack.